### PR TITLE
Problem: no info how to buy File storage for DW and difficult to find…

### DIFF
--- a/sections/dataworkbench/datacatalogue.md
+++ b/sections/dataworkbench/datacatalogue.md
@@ -169,43 +169,6 @@ To revoke access to a data set:
 When you revoke a user's or workspace's access to a data set, they are notified about that by email. Also, if they have reshared the data set with other people, they will loose access to the data set too.
 
 ## File storage
-Note that this feature is only available for the workspaces that have a subscription for File storage.
+Note that this feature is only available for the workspaces that have a subscription for File storage. You can [purchase File storage for Veracity Data Workbench here](https://store.veracity.com/veracity-file-storage-data-workbench).
 
-To go to File storage:
-1. In your workspace, go to **Data catalogue** page.
-2. Select the **File storage** tab.
-
-### To upload files
-1. In the top right corner, select **Upload files**. You can upload multiple files at once.
-2. Select the coloured circle with the file icon and select the files from your computer. Alternatively, drag and drop files.
-3. Select **Upload**.
-
-### Folders
-In File storage, you can use folders to organize files. If you are a workspace admin, you can create folders.
-
-To create a folder:
-1. In the top right corner, select **Create folder**.
-2. Name the folder.
-3. Select **Save**.
-
-### To delete files and folders
-If you are a workspace admin, you can delete files and folders. To do so:
-1. In the row with the file or folder you want to delete, on the right, select three dots.
-2. Select **Delete**.
-3. In the window that shows, confirm by selecting **Delete**.
-
-Note that deleting is permanent, and cannot be undone.
-
-### To download files and folders
-If you are a workspace reader or admin, you can download files and folders. To do so:
-1. In the row with the file or folder you want to download, on the right, select three dots.
-2. Select **Download**.
-
-### To generate a SAS token
-If you are a workspace admin, you can generate access keys to files and folders and use them in external systems. To do so:
-1. In the row with a file or folder you want to generate a SAS token for, on the right, select three dots.
-2. Under **Set access level**, choose access level (read or read and write).
-3. Optionally, under **Set access start**, choose a date from which this file or folder should be accessible.
-4. Under **Set access end**, choose a date from which this file or folder will no longer be accessible.
-5. Select **Generate key** and a new field called **Access key** will show.
-6. Select **Copy key**. 
+[Go here for File storage documentation](filestorage.md).

--- a/sections/dataworkbench/filestorage.md
+++ b/sections/dataworkbench/filestorage.md
@@ -1,8 +1,19 @@
 ---
 author: Veracity
-description: This page contains an overview of File storage in Data Workbench.
+description: This page explains how to use File storage in Data Workbench and how to migrate to it from Data Fabric.
 ---
-# Migrating from Data Fabric
+# File storage
+This page explains how to use File storage in Data Workbench and **how to migrate to it from Data Fabric**.
+
+## Prerequisites
+1. You need Veracity Data Workbench. 
+2. You need File storage, which is an additional feature for Data Workbench.
+
+You can purchase them on Veracity Marketplace:
+* [Purchase Veracity Data Workbench](https://store.veracity.com/data-workbench).
+* [Purchase file storage for Veracity Data Workbench](https://store.veracity.com/veracity-file-storage-data-workbench).
+
+Note that you might already have access to them as a part of another service you purchased from Veracity.
 
 ## Account activation process
 Before you can start using Data Workbench with storage functionality, your account needs to be activated. Once you have completed the subscription purchase, Veracity will set up your account. Once the setup is complete, you will receive an activation email. After receiving this email, you can begin using Data Workbench with full storage capabilities.

--- a/sections/vap/file-storage-as-data-source/introduction.md
+++ b/sections/vap/file-storage-as-data-source/introduction.md
@@ -13,6 +13,6 @@ The guide will take you through the following steps.
 1. Create a Power BI report using Data Workbench File storage. In this part, you will also learn how to update data in Data Workbench and refresh file to get new data in VAP, upload a Power BI file in VAP, and enable a scheduled refresh on report to get fresh data.
 2. Optionally, if your Power BI file was connected to Data Fabric, connect it to Data Workbench File storage.
 
-For more information about Veracity Data Workbench File storage, see its documentation [here](https://developer.veracity.com/docs/section/dataworkbench/datacatalogue#file-storage). 
+For more information about Veracity Data Workbench File storage, see its documentation [here](../../dataworkbench/filestorage.md). 
 
 Let us get started with [step 1](create-report.md).


### PR DESCRIPTION
… tutorials on using File storage. Solution:

1. I renamed the document “Migrating from Data Fabric” to “File storage”, and I made it clear at the beginning that it covers File storage and migrating from Data Fabric.
2. I changed the link in VAP document so that it links to the “File storage” document with images and details on using File storage.
3. In the “File storage” file and in “Data catalogue”, I linked to the Marketplace page where you can purchase File storage.
4. In “Data catalogue”, I removed the docs on File storage and I linked to the page on “File storage” for details.