### PR TITLE
Wrong link to filestorage

### DIFF
--- a/sections/datafabric/datafabric-migration.md
+++ b/sections/datafabric/datafabric-migration.md
@@ -43,7 +43,7 @@ Whether you decide for option 1 or 2 above, you must communicate the change to t
 
 __Are you using data from Data Fabric into a Power BI reports?__
 1. Download your data from Data Fabric / My data (please refer to our [Download Guide](https://developer.veracity.com/docs/section/datafabric/tutorials/download-my-data)).
-2. Subscribe to "[Data Workbench Storage](https://store.veracity.com/6-ea69-4b8c-9c72-df35f2a00)" and upload your data here. Once your subscription is confirmed, you will receive an activation email. Please note that this might take up to a few days. When the activation is completed, you are ready to start using Veracity Data Workbench. [Read the How-To Guide for an introduction](https://developer.veracity.com/docs/section/dataworkbench/filestorage).
+2. Subscribe to "[Data Workbench Storage](https://store.veracity.com/6-ea69-4b8c-9c72-df35f2a00)" and upload your data here. Once your subscription is confirmed, you will receive an activation email. Please note that this might take up to a few days. When the activation is completed, you are ready to start using Veracity Data Workbench. [Read the How-To Guide for an introduction](https://developer.veracity.com/docs/section/dataworkbench/filestorage/filestorage).
 3. When you have completed the onboarding on Data Workbench, please refer to the guide [Using Veracity Data Workbench File storage as a data source for Power BI](https://developer.veracity.com/docs/section/vap/file-storage-as-data-source/introduction). 
 
 ## Inform users of your data


### PR DESCRIPTION
I believe the wrong link is being referred to in the documentation. The link that is 
 working is https://developer.veracity.com/docs/section/dataworkbench/filestorage/filestorage with a duplicated "filestorage" in the end. If the error is on the link url then the files location must be modified.